### PR TITLE
Loosen requests dependency pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.28.1
+requests~=2.28

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages =
     pyfibaro
     pyfibaro.common
 install_requires =
-    requests~=2.28.1
+    requests~=2.28
 python_requires = >=3.9
 include_package_data = True
 package_dir =


### PR DESCRIPTION
This PR loosens the dependency pinning for `requests`.

Blocks: <https://github.com/home-assistant/core/pull/92231>