### PR TITLE
Handle emptry string as modes

### DIFF
--- a/pyfibaro/fibaro_device.py
+++ b/pyfibaro/fibaro_device.py
@@ -227,7 +227,7 @@ class DeviceModel:
         """Returns the supported modes, for example for fan or hvac devices."""
         if "supportedModes" in self.properties:
             modes = self.properties.get("supportedModes")
-            if isinstance(modes, str):
+            if isinstance(modes, str) and modes != "":
                 return [int(mode) for mode in modes.split(",")]
             if isinstance(modes, list):
                 return [int(mode) for mode in modes]


### PR DESCRIPTION
According to issue https://github.com/home-assistant/core/issues/96968, the string can be empty, and the `int()` doesn't like empty strings.