### PR TITLE
Relax build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools~=67.7", "wheel~=0.40"]
+requires = ["setuptools>=67.7"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
In [nixpkgs](https://github.com/NixOS/nixpkgs), we have updated `setuptools` to v68.0.0 and will likely try to update it to v68.1.2 soon. We use [`build`](https://pypa-build.readthedocs.io/en/stable/) to run Python builds, and it checks dependency constraints defined in pyproject.toml.

This PR relaxes the constraint on setuptools. It also removes `wheel` from being listed explicitly: it will be included for wheel builds by setuptools, and it will not be included for sdist builds. The [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html) says: 

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).