### PR TITLE
Add support for Zooz Z-Box Hub

### DIFF
--- a/pyfibaro/common/const.py
+++ b/pyfibaro/common/const.py
@@ -14,7 +14,7 @@ HTTP_HEADERS = {
 }
 
 # Match serial number prefix to a interface version
-API_VERSION_MATCHER = {"HC2": 4, "HCL": 4, "HC3": 5, "HC3L": 5, "YH": 5}
+API_VERSION_MATCHER = {"HC2": 4, "HCL": 4, "HC3": 5, "HC3L": 5, "YH": 5, "ZB": 5}
 
 # Devices which are ignored
 # iOS_device includes iOS and Android devices


### PR DESCRIPTION
`[Z-Box Hub](https://zboxhub.com/)` uses API version 5. This PR enables scenes to work properly for these devices.

I tested this by making a local patch to the pyfibaro library and verified that the correct REST requests were being sent to my Z-Box and that the scenes operated correctly.